### PR TITLE
[IMP] Added the possibility to choose the font of each element in the dialog #1

### DIFF
--- a/src/lib/ConfirmProvider.tsx
+++ b/src/lib/ConfirmProvider.tsx
@@ -8,6 +8,9 @@ type ConfirmOptions = {
   confirmText?: string
   cancelText?: string
   confirmColor?: string
+  confirmTextFont?: string
+  cancelTextFont?: string
+  dialogTextFont?:string
 }
 
 type ConfirmFunction = (options: ConfirmOptions) => Promise<boolean>
@@ -48,7 +51,7 @@ export const ConfirmProvider = ({ children }: { children: ReactNode }) => {
     boxShadow: "0 4px 12px rgba(0,0,0,0.3)",
     maxWidth: "400px",
     width: "90%",
-    fontFamily:"sans-serif"
+    fontFamily:options?.dialogTextFont,
   }
 
   const buttonStyle: React.CSSProperties = {
@@ -64,12 +67,14 @@ export const ConfirmProvider = ({ children }: { children: ReactNode }) => {
     backgroundColor: "#e0e0e0",
     color: "#333",
     marginRight: "0.5rem",
+    fontFamily: options?.cancelTextFont,
   }
 
   const confirmButtonStyle: React.CSSProperties = {
     ...buttonStyle,
     backgroundColor: options?.confirmColor || "#2563eb", // blue default
     color: "white",
+    fontFamily : options?.confirmTextFont,
   }
 
   return (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,6 +12,9 @@ const App = () => {
       confirmText: "Delete",
       cancelText: "Cancel",
       confirmColor: "#dc2626",
+      confirmTextFont: "monospace", // change with the font of your choice
+      cancelTextFont: "monospace",
+      dialogTextFont :"monospace"
     })
 
     if (ok) {
@@ -23,7 +26,7 @@ const App = () => {
 
   return (
     <div style={{ padding: "2rem" }}>
-      <button onClick={handleDelete} style={{ padding: "0.75rem 1.5rem", fontSize: "1rem",fontFamily:'sans-serif' }}>
+      <button onClick={handleDelete} style={{ padding: "0.75rem 1.5rem", fontSize: "1rem" }}>
         Delete File
       </button>
     </div>


### PR DESCRIPTION
Description
This improvement introduces support for customizing the font family of individual elements in the confirmation dialog. Now, developers can specify fonts for components such as:

Dialog Body Text

Confirm button

Cancel button

This makes it easier to align the dialog styling with the overall design system or app branding.
How to Use
```
  const handleDelete = async () => {
    const ok = await confirm({
      title: "Delete file?",
      message: "Are you sure you want to delete this file? This action cannot be undone.",
      confirmText: "Delete",
      cancelText: "Cancel",
      confirmColor: "#dc2626",
    })
```
Checklist
✅ Feature implemented

✅ Code tested locally

Documentation not yet updated